### PR TITLE
Split test and disassembly workflows

### DIFF
--- a/.github/workflows/compare-bytecode.yml
+++ b/.github/workflows/compare-bytecode.yml
@@ -2,6 +2,8 @@ name: Compare Python 3.13 vs 3.14 Bytecode
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/compare-bytecode.yml
+++ b/.github/workflows/compare-bytecode.yml
@@ -18,10 +18,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: pip install -U pytest
-      - name: Run interpreter tests
-        run: pytest -q
       - name: Disassemble samples
         run: |
           mkdir out-${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Run Interpreter Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13.3', '3.14-dev']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install -U pytest
+      - name: Run test suite
+        run: pytest -vv --log-cli-level=INFO

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Run Interpreter Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ versions.
 1. Install dependencies and run the tests:
    ```bash
    pip install -U pytest
-   pytest -q
+   pytest -vv --log-cli-level=INFO
    ```
 2. Run the interpreter on a sample:
    ```bash


### PR DESCRIPTION
## Summary
- separate out a workflow for running pytest
- remove the test step from the bytecode comparison workflow
- run pytest with higher verbosity and show log output

## Testing
- `pytest -vv --log-cli-level=INFO`


------
https://chatgpt.com/codex/tasks/task_e_685995e58a18833299bb39b1fce3c298