### PR TITLE
Add loop and conditional examples

### DIFF
--- a/samples/calls.py
+++ b/samples/calls.py
@@ -1,0 +1,3 @@
+nums = (1, 2, 3)
+result = sum(nums)
+print(result)

--- a/samples/conditionals.py
+++ b/samples/conditionals.py
@@ -1,0 +1,5 @@
+x = 1
+if x > 0:
+    print("positive")
+else:
+    print("non-positive")

--- a/samples/loops.py
+++ b/samples/loops.py
@@ -1,0 +1,2 @@
+for i in range(3):
+    print(i)

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -65,8 +65,8 @@ class MiniInterpreter:
             value = next(iterator)
             self.stack.append(value)
         except StopIteration:
-            self.stack.pop()
             self.pc = target
+            self.stack.append(None)
 
     def op_JUMP_BACKWARD(self, arg, consts, names):
         instr = self.instructions[self.pc - 1]
@@ -74,7 +74,9 @@ class MiniInterpreter:
         self.pc = target
 
     def op_END_FOR(self, arg, consts, names):
-        pass
+        # iterator is below the sentinel pushed by FOR_ITER
+        if len(self.stack) >= 2:
+            self.stack.pop(-2)
 
     def op_COMPARE_OP(self, arg, consts, names):
         instr = self.instructions[self.pc - 1]

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -2,10 +2,25 @@ import subprocess
 import sys
 
 
+def run_sample(filename: str) -> str:
+    """Execute the mini interpreter on *filename* and return stdout."""
+    return subprocess.check_output(
+        [sys.executable, 'src/interpreter.py', f'samples/{filename}'],
+        text=True,
+    ).strip()
+
+
 def test_run_hello(tmp_path):
-    out = subprocess.check_output([
-        sys.executable,
-        'src/interpreter.py',
-        'samples/hello.py'
-    ], text=True)
-    assert out.strip() == 'hello world'
+    assert run_sample('hello.py') == 'hello world'
+
+
+def test_run_loops(tmp_path):
+    assert run_sample('loops.py') == '0\n1\n2'
+
+
+def test_run_conditionals(tmp_path):
+    assert run_sample('conditionals.py') == 'positive'
+
+
+def test_run_calls(tmp_path):
+    assert run_sample('calls.py') == '6'


### PR DESCRIPTION
## Summary
- support loops and conditional comparisons in the interpreter
- add loop/conditional/call sample programs
- expand interpreter test coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859990519488332b128c5a559163bdf