### PR TITLE
Include source code in diff report

### DIFF
--- a/.github/workflows/compare-bytecode.yml
+++ b/.github/workflows/compare-bytecode.yml
@@ -48,12 +48,9 @@ jobs:
         with:
           name: disasm-3.14-dev
           path: disasm/3.14-dev
-      - name: Compare JSON outputs
+      - name: Generate diff report
         run: |
-          echo "## Bytecode diffs (3.13.3 → 3.14-dev)" > BYTECODE_DIFF.md
-          for f in samples/*.py; do
-            diff -u disasm/3.13.3/$(basename "$f").json disasm/3.14-dev/$(basename "$f").json || true
-          done >> BYTECODE_DIFF.md
+          python scripts/generate_diff_report.py disasm/3.13.3 disasm/3.14-dev
       - name: Upload diff report
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ versions.
    This will output a JSON file with timing information.
 4. Inspect bytecode differences by running the GitHub Actions workflow which
    disassembles the samples on both Python 3.13.3 and 3.14-dev and produces a
-   `BYTECODE_DIFF.md` report. The workflow uploads this file as the
-   `bytecode-diffs` artifact so you can view it directly from the Actions tab.
+   `BYTECODE_DIFF.md` report. The report now includes the source code of each
+   sample for context along with the bytecode diff. The workflow uploads this
+   file as the `bytecode-diffs` artifact so you can view it directly from the
+   Actions tab.
 
 ## License
 

--- a/scripts/generate_diff_report.py
+++ b/scripts/generate_diff_report.py
@@ -1,0 +1,46 @@
+import difflib
+from pathlib import Path
+import argparse
+
+HEADER = "## Bytecode diffs (3.13.3 → 3.14-dev)"
+
+
+def diff_json(old, new):
+    old_lines = Path(old).read_text().splitlines()
+    new_lines = Path(new).read_text().splitlines()
+    return list(difflib.unified_diff(old_lines, new_lines, fromfile=str(old), tofile=str(new)))
+
+
+def generate(samples, old_dir, new_dir, output):
+    lines = [HEADER, ""]
+    for sample in samples:
+        lines.append(f"### {sample}")
+        lines.append("")
+        lines.append("```python")
+        lines.extend(Path(sample).read_text().splitlines())
+        lines.append("```")
+        lines.append("")
+        old_json = Path(old_dir) / f"{Path(sample).name}.json"
+        new_json = Path(new_dir) / f"{Path(sample).name}.json"
+        diff_lines = diff_json(old_json, new_json)
+        lines.append("```diff")
+        lines.extend(diff_lines)
+        lines.append("```")
+        lines.append("")
+    Path(output).write_text("\n".join(lines))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Generate bytecode diff report with source code.")
+    parser.add_argument("old_dir", help="directory with old version disassembly")
+    parser.add_argument("new_dir", help="directory with new version disassembly")
+    parser.add_argument("samples", nargs="*", default=None, help="sample files")
+    parser.add_argument("-o", "--output", default="BYTECODE_DIFF.md", help="output markdown file")
+    args = parser.parse_args(argv)
+
+    sample_files = args.samples or [str(p) for p in Path("samples").glob("*.py")]
+    generate(sample_files, args.old_dir, args.new_dir, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to generate diff reports that include sample source code
- update workflow to use the new script
- document the enhanced bytecode report in the README

## Testing
- `pytest -vv --log-cli-level=INFO`

------
https://chatgpt.com/codex/tasks/task_e_6859a211f05c8332b152efa8c31ac0d9